### PR TITLE
We should see all planets

### DIFF
--- a/OGame UI++/script.js
+++ b/OGame UI++/script.js
@@ -956,25 +956,32 @@ var userscript = function() {
 	  // If we are on the galaxy view.
 
   if(window.location.href.indexOf("galaxy") > -1) {
-  	$(window).bind("load", function() {
-  		console.log("im here");
-		$(".playername").mouseenter(function(){
-			console.log("DOING");
-			if($(this).attr("added") !== "1"){
-				$(this).attr("added","1");
-				var id = $(this).find('a').first().attr('rel');
-				if (id){
-					var id_filtered = id.replace('player','');
-					var planets = config.players[id_filtered].planets;
-					var string = ""
-					for (var i = 0; i < planets.length; i++){
-						string = string+'<td><a href="/game/index.php?page=galaxy&galaxy='+ planets[i].coords[0] +'&system='+ planets[i].coords[1] +'&position='+ planets[i].coords[2] +'">[' + planets[i].coords[0] + ':' + planets[i].coords[1] + ':' + planets[i].coords[2] + ']</a></td><br>'
+  	//window.location.reload();
+  	 var interval = setInterval(function() {
+	   if ($(".playername").length) {
+	   	console.log($(".playername").length);
+		  $(".playername").mouseenter(function(){
+				if($(this).attr("added") !== "1"){
+					$(this).attr("added","1");
+					var id = $(this).find('a').first().attr('rel');
+					if (id){
+						var id_filtered = id.replace('player','');
+						var planets = config.players[id_filtered].planets;
+						console.log(planets);
+						var string = ""
+						for (var i = 0; i < planets.length; i++){
+							string = string+'<td><a href="/game/index.php?page=galaxy&galaxy='+ planets[i].coords[0] +'&system='+ planets[i].coords[1] +'&position='+ planets[i].coords[2] +'">[' + planets[i].coords[0] + ':' + planets[i].coords[1] + ':' + planets[i].coords[2] + ']</a></td><br>'
+						}
+						$('#'+id).append(string);
 					}
-					$('#'+id).append(string);
 				}
-			}
-		});
-	});
+			});
+		  clearTimeout(interval);
+		}
+	   
+	}, 100); // check every 100ms
+  		
+
   }
 };
 

--- a/OGame UI++/script.js
+++ b/OGame UI++/script.js
@@ -953,7 +953,7 @@ var userscript = function() {
       console.log('players', players);
     });
   }
-	  // If we are on the galaxy view.
+	  
 
 
 // See all player planets on Galaxy view.
@@ -990,7 +990,8 @@ var userscript = function() {
       setTimeout(setAllPlanets,600);
     }
   }
-
+  
+  // If we are on the galaxy view.
   if(window.location.href.indexOf("galaxy") > -1) {
   	$(".galaxy_icons.next").each(function(){
   		var funct = $(this).attr("onclick");

--- a/OGame UI++/script.js
+++ b/OGame UI++/script.js
@@ -812,6 +812,35 @@ var userscript = function() {
       localStorage.setItem('og-enhancements', JSON.stringify(config));
     }
   }
+  
+  window.getAllPlanets = function(player_id){
+  	$.ajax({
+      url : '/api/playerData.xml?id='+player_id,
+      dataType: 'xml',
+      success: function(data) {
+      	var player = player_id;
+      	if(config.players[player]){
+      		config.players[player].planets = [];
+      	}
+        $('planet', data).each(function() {
+              el = $(this);
+              name = el.attr('name');
+              coords = el.attr('coords').split(':');
+              coords[0] = parseInt(coords[0]);
+              coords[1] = parseInt(coords[1]);
+              coords[2] = parseInt(coords[2]);
+              if (config.players[player]) {
+                  config.players[player].planets.push({
+                  name: name,
+                  coords: coords
+                });
+              }
+         });
+        saveConfig(config);
+       	return config.players[player].planets;
+    	}
+	});
+  }
 
   function loadUniverseApi(cb) {
     $.ajax({
@@ -924,7 +953,31 @@ var userscript = function() {
       console.log('players', players);
     });
   }
+	  // If we are on the galaxy view.
+
+  if(window.location.href.indexOf("galaxy") > -1) {
+  	$(window).bind("load", function() {
+  		console.log("im here");
+		$(".playername").mouseenter(function(){
+			console.log("DOING");
+			if($(this).attr("added") !== "1"){
+				$(this).attr("added","1");
+				var id = $(this).find('a').first().attr('rel');
+				if (id){
+					var id_filtered = id.replace('player','');
+					var planets = config.players[id_filtered].planets;
+					var string = ""
+					for (var i = 0; i < planets.length; i++){
+						string = string+'<td><a href="/game/index.php?page=galaxy&galaxy='+ planets[i].coords[0] +'&system='+ planets[i].coords[1] +'&position='+ planets[i].coords[2] +'">[' + planets[i].coords[0] + ':' + planets[i].coords[1] + ':' + planets[i].coords[2] + ']</a></td><br>'
+					}
+					$('#'+id).append(string);
+				}
+			}
+		});
+	});
+  }
 };
+
 
 // inject user script into the document
 var script = document.createElement('script');

--- a/OGame UI++/script.js
+++ b/OGame UI++/script.js
@@ -955,44 +955,63 @@ var userscript = function() {
   }
 	  // If we are on the galaxy view.
 
+
+// See all player planets on Galaxy view.
    window.setAllPlanets = function(){
+    console.log("YES");
    	var interval = setInterval(function() {
-	   if ($(".playername").length) {
-	   	console.log($(".playername").length);
-		  $(".playername").mouseenter(function(){
-				if($(this).attr("added") !== "1"){
-					$(this).attr("added","1");
-					var id = $(this).find('a').first().attr('rel');
-					if (id){
-						var id_filtered = id.replace('player','');
-						var planets = config.players[id_filtered].planets;
-						console.log(planets);
-						var string = ""
-						for (var i = 0; i < planets.length; i++){
-							console.log(planets[i].name);
-							string = string+'<tr><td>'+planets[i].name+'<a href="/game/index.php?page=galaxy&galaxy='+ planets[i].coords[0] +'&system='+ planets[i].coords[1] +'&position='+ planets[i].coords[2] +'">[' + planets[i].coords[0] + ':' + planets[i].coords[1] + ':' + planets[i].coords[2] + ']</a></td></tr>';
-						}
-						$('#'+id).append(string);
-					}
-				}
-			});
+     var already = []
+	   if ($(".playername").length && ($("#galaxyLoading").css("display") === "none")) {
+      $(".playername").each(function(){
+        console.log("Executing");
+          var id = $(this).find('a').first().attr('rel');
+          if(!(already.indexOf(id) != -1)){
+            if (id){
+            already.push(id);
+            var id_filtered = id.replace('player','');
+            var planets = config.players[id_filtered].planets;
+            var string = ""
+            for (var i = 0; i < planets.length; i++){
+              string = string+'<tr><td>'+planets[i].name+'<a href="/game/index.php?page=galaxy&galaxy='+ planets[i].coords[0] +'&system='+ planets[i].coords[1] +'&position='+ planets[i].coords[2] +'">[' + planets[i].coords[0] + ':' + planets[i].coords[1] + ':' + planets[i].coords[2] + ']</a></td></tr>';
+            }
+            $('[id='+id+']').append(string);
+          }
+          }
+        }
+      );
 		  clearTimeout(interval);
 		}
 	   
 	}, 100); // check every 100ms
+  };
 
-   };
+  window.setPlanetOnEnter = function(event){
+    if (window.event.keyCode == 13){
+      setTimeout(setAllPlanets,600);
+    }
+  }
 
   if(window.location.href.indexOf("galaxy") > -1) {
-//  	$(".galaxy_icons.next").attr("onclick","eval(wrapperFunc("+getParameter($(this).attr("onclick"))+"));");
   	$(".galaxy_icons.next").each(function(){
   		var funct = $(this).attr("onclick");
-  		$(this).attr("onclick",funct+"setTimeout(setAllPlanets,1000);");
+  		$(this).attr("onclick",funct+"setTimeout(setAllPlanets,600);");
   	})
   	$(".galaxy_icons.prev").each(function(){
   		var funct = $(this).attr("onclick");
-  		$(this).attr("onclick",funct+"setTimeout(setAllPlanets,1000);");
+  		$(this).attr("onclick",funct+"setTimeout(setAllPlanets,600);");
   	})
+    $(".btn_blue").each(function(){
+      var funct = $(this).attr("onclick");
+      $(this).attr("onclick",funct+"setTimeout(setAllPlanets,600);");
+    })
+    $("#system_input").each(function(){
+      var funct = $(this).attr("onkeypress");
+      $(this).attr("onkeypress","setPlanetOnEnter(event);"+funct);
+    })
+    $("#galaxy_input").each(function(){
+      var funct = $(this).attr("onkeypress");
+      $(this).attr("onkeypress","setPlanetOnEnter(event);"+funct);
+    })
   	setAllPlanets();
   }
 };

--- a/OGame UI++/script.js
+++ b/OGame UI++/script.js
@@ -955,9 +955,8 @@ var userscript = function() {
   }
 	  // If we are on the galaxy view.
 
-  if(window.location.href.indexOf("galaxy") > -1) {
-  	//window.location.reload();
-  	 var interval = setInterval(function() {
+   window.setAllPlanets = function(){
+   	var interval = setInterval(function() {
 	   if ($(".playername").length) {
 	   	console.log($(".playername").length);
 		  $(".playername").mouseenter(function(){
@@ -970,7 +969,8 @@ var userscript = function() {
 						console.log(planets);
 						var string = ""
 						for (var i = 0; i < planets.length; i++){
-							string = string+'<td><a href="/game/index.php?page=galaxy&galaxy='+ planets[i].coords[0] +'&system='+ planets[i].coords[1] +'&position='+ planets[i].coords[2] +'">[' + planets[i].coords[0] + ':' + planets[i].coords[1] + ':' + planets[i].coords[2] + ']</a></td><br>'
+							console.log(planets[i].name);
+							string = string+'<tr><td>'+planets[i].name+'<a href="/game/index.php?page=galaxy&galaxy='+ planets[i].coords[0] +'&system='+ planets[i].coords[1] +'&position='+ planets[i].coords[2] +'">[' + planets[i].coords[0] + ':' + planets[i].coords[1] + ':' + planets[i].coords[2] + ']</a></td></tr>';
 						}
 						$('#'+id).append(string);
 					}
@@ -980,8 +980,20 @@ var userscript = function() {
 		}
 	   
 	}, 100); // check every 100ms
-  		
 
+   };
+
+  if(window.location.href.indexOf("galaxy") > -1) {
+//  	$(".galaxy_icons.next").attr("onclick","eval(wrapperFunc("+getParameter($(this).attr("onclick"))+"));");
+  	$(".galaxy_icons.next").each(function(){
+  		var funct = $(this).attr("onclick");
+  		$(this).attr("onclick",funct+"setTimeout(setAllPlanets,1000);");
+  	})
+  	$(".galaxy_icons.prev").each(function(){
+  		var funct = $(this).attr("onclick");
+  		$(this).attr("onclick",funct+"setTimeout(setAllPlanets,1000);");
+  	})
+  	setAllPlanets();
   }
 };
 


### PR DESCRIPTION
THIS PULL IS NOT READY TO BE MERGED

Ignoring the window.getAllPlanets = function

I'm having a problem trying to display all planets from a user.
Basically If im on the galaxy view,  I would like to be able to see all the player planets when i hover on the player name.

Whats the main problem?
$(window).bind("load", function() {...
Seems to be called only ONCE , after that you need to reload the plugin so it works?

I don't know what i'm missing. .

---------------------------------

Seems like ogame whenever you navigate through tabs, doesn't reload website, 
setInterval made the trick. Now i need  a way to hook to galaxy movements (Chagne galaxy, change system) so i call the function again.


---------------------------------

BOY IS WORKING!
We just need to fix, that sometimes, planet names get a little messy inside the window when some player has more than 1 planet in the same galaxy, since $('#'+id) don't care about order.

![image](https://cloud.githubusercontent.com/assets/9058818/20033013/f9788d62-a36c-11e6-9299-30d186085928.png)


THIS PULL IS NOT READY TO BE MERGED

