### PR TITLE
FIX: chrome refuse to load manifest: 'Manifest is not valid JSON. Lin…

### DIFF
--- a/OGame UI++/manifest.json
+++ b/OGame UI++/manifest.json
@@ -7,7 +7,7 @@
       "exclude_matches": [  ],
       "include_globs": [  ],
       "css": [
-        "lib/chartist.min.css",
+        "lib/chartist.min.css"
       ],
       "js": [
         "src/utils/edit-note.js",


### PR DESCRIPTION
…e: 11, column: 8, Trailing comma not allowed.'