### PR TITLE
F: remove old backups and some undefined configs

### DIFF
--- a/OGame UI++/src/utils/persistent-config.js
+++ b/OGame UI++/src/utils/persistent-config.js
@@ -13,6 +13,16 @@ var fn = function () {
     localStorage.removeItem(configKey);
     localStorage.setItem(configKey + '-' + playerId, oldConfig);
   }
+
+  // remove backups and undefined configs for more free space
+  var patt = new RegExp(configKey + '-' + '\\d+$');
+  for (var key in localStorage) {
+    if (key.indexOf(configKey) === 0 && !patt.test(key)) {
+      window.console.log('OGame UI++ : removing \'' + key + '\' from localStorage');
+      localStorage.removeItem(key);
+    }
+  }
+
   configKey += '-' + playerId;
 
   function saveConfig () {


### PR DESCRIPTION
Today suddenly uipp stopped working. I've found some old configs `og-enhancements-backup1`, `og-enhancements-backup2` and `og-enhancements-undefined` in localStorage. This lead to fail on saving new config due to out of free space. So how about to remove some old and undefined configs?