### PR TITLE
fixed bug when resource text is too long, the violet text is overlapping

### DIFF
--- a/OGame UI++/src/current-planet-storage-helper.js
+++ b/OGame UI++/src/current-planet-storage-helper.js
@@ -2,12 +2,30 @@ var fn = function () {
   'use strict';
   window._addCurrentPlanetStorageHelper = function _addCurrentPlanetStorageHelper () {
     var resources = window._getCurrentPlanetResources();
+    var resourcesArr = ['metal', 'crystal', 'deuterium'];
+    var tooltips = JSON.parse(
+      window.initAjaxResourcebox.toString()
+        .replace('function initAjaxResourcebox(){reloadResources(', '')
+        .replace(new RegExp('\\);}$'), '')
+    );
 
     if (resources) {
-      // indicates storage left (in time) and total storage time
-      $('#metal_box .value').append('<br><span class="enhancement storageleft">' + window._time((resources.metal.max - resources.metal.now) / resources.metal.prod, -1) + (window._time(resources.metal.max / resources.metal.prod).length > 0 ? ' (' + window._time(resources.metal.max / resources.metal.prod) + ')' : '') + '</span>');
-      $('#crystal_box .value').append('<br><span class="enhancement storageleft">' + window._time((resources.crystal.max - resources.crystal.now) / resources.crystal.prod, -1) + (window._time(resources.crystal.max / resources.crystal.prod).length > 0 ? ' (' + window._time(resources.crystal.max / resources.crystal.prod) + ')' : '') + '</span>');
-      $('#deuterium_box .value').append('<br><span class="enhancement storageleft">' + window._time((resources.deuterium.max - resources.deuterium.now) / resources.deuterium.prod, -1) + (window._time(resources.deuterium.max / resources.deuterium.prod).length > 0 ? ' (' + window._time(resources.deuterium.max / resources.deuterium.prod) + ')' : '') + '</span>');
+      for (var i = 0; i < resourcesArr.length; i++) {
+        // indicates storage left (in time)
+        $('#' + resourcesArr[i] + '_box .value').append('<br><span class="enhancement storageleft">' + window._time((resources[resourcesArr[i]].max - resources[resourcesArr[i]].now) / resources[resourcesArr[i]].prod, -1) + '</span>');
+
+        // add indicators to tooltip
+        var tempTooltip = tooltips[resourcesArr[i]].tooltip.replace(
+          '</table>',
+          [
+            '<tr class="enhancement"><th>Time untill full:</th><td>' + window._time((resources[resourcesArr[i]].max - resources[resourcesArr[i]].now) / resources[resourcesArr[i]].prod, -1) + '</td></tr>',
+            '<tr class="enhancement"><th>Total storage time:</th><td>' + (window._time(resources[resourcesArr[i]].max / resources[resourcesArr[i]].prod).length > 0 ? window._time(resources[resourcesArr[i]].max / resources[resourcesArr[i]].prod) : '') + '</td></tr>',
+            '</table>'
+          ].join('')
+        );
+
+        changeTooltip($('#' + resourcesArr[i] + '_box'), tempTooltip);
+      }
     }
   };
 };


### PR DESCRIPTION
This fixes issue #16 

Not sure if you like it but I'm looping over the resourcesArr instead of having everything duplicated 3 times.

PS: do we need to add `Time untill full` and `Total storage time` to a translation file?